### PR TITLE
Add leak-free version of substr and strtrim

### DIFF
--- a/cub3d/src/cub3d.h
+++ b/cub3d/src/cub3d.h
@@ -1,0 +1,44 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cub3d.h                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: jsolinis <jsolinis@student.42urduli>       +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2022/05/18 23:29:00 by jsolinis          #+#    #+#             */
+/*   Updated: 2022/05/18 23:30:22 by jsolinis         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef CUBE3D_H
+# define CUBE3D_H
+
+#include <stdio.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+/* Utils */
+int     ft_open_file(char *file_path);
+int     ft_isspace(char c);
+void    ft_skip_to_non_space_char(char *line, int *iterator);
+char	*get_next_line(int fd);
+char    *ft_substr_no_leaks(char *s, unsigned int start, size_t len);
+char    *ft_strtrim_no_leaks(char *s1, const char *set);
+
+/* Common errors */
+void    ft_malloc_error(void);
+void    ft_open_file_error(void);
+
+/* Scene description file validation */
+void    ft_check_num_args(int argc);
+void    ft_scene_desc_file_validation(char *file_path);
+void    ft_file_extension_validation(char *file_path);
+void    ft_type_ids_validation(char *file_path);
+int    ft_open_scene_file(char *file_path);
+void    ft_validate_scene_file_line(char *line);
+void    ft_parse_orientation_path(char *line, int *i);
+void    ft_validate_orientation_path(char *o_path_acronym, char *line, int *i);
+int     ft_calc_path_length(char *line, int i);
+
+#endif

--- a/cub3d/src/utils/ft_utils.c
+++ b/cub3d/src/utils/ft_utils.c
@@ -1,0 +1,51 @@
+#include "../cub3d.h"
+#include "../../Libft/libft.h"
+
+int    ft_open_file(char *file_path)
+{
+    int     file_fd;
+
+    file_fd = open(file_path, O_RDONLY);
+    if (file_fd == -1)
+    {
+        free(file_path);
+        ft_open_file_error();
+    }
+    return(file_fd);  
+}
+
+int ft_isspace(char c)
+{
+    if (c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r')
+        return (1);
+    return (0);
+}
+
+void    ft_skip_to_non_space_char(char *line, int *iterator)
+{
+    while(line[*iterator] != '\0')
+    {
+        if (ft_isspace(line[*iterator]))
+            *iterator += 1;
+        else
+            return;
+    }
+}
+
+char    *ft_substr_no_leaks(char *s, unsigned int start, size_t len)
+{
+    char    *temp;
+
+    temp = ft_substr(s, start, len);
+    free(s);
+    return (temp);
+}
+
+char *ft_strtrim_no_leaks(char *s1, const char *set)
+{
+    char    *temp;
+
+    temp = ft_strtrim(s1, set);
+    free(s1);
+    return (temp);
+}


### PR DESCRIPTION
Add two new util functions for leak-free version of substr and strtrim. Only applies in cases when the string the return value is being assigned to was already malloc'ed.