### PR TITLE
Add leak-free versions of substr and strtrim

### DIFF
--- a/cub3d/src/cub3d.h
+++ b/cub3d/src/cub3d.h
@@ -23,6 +23,8 @@ int     ft_open_file(char *file_path);
 int     ft_isspace(char c);
 void    ft_skip_to_non_space_char(char *line, int *iterator);
 char	*get_next_line(int fd);
+char    *ft_substr_no_leaks(char *s, unsigned int start, size_t len);
+char    *ft_strtrim_no_leaks(char *s1, const char *set);
 
 /* Common errors */
 void    ft_malloc_error(void);

--- a/cub3d/src/utils/ft_utils.c
+++ b/cub3d/src/utils/ft_utils.c
@@ -31,3 +31,21 @@ void    ft_skip_to_non_space_char(char *line, int *iterator)
             return;
     }
 }
+
+char    *ft_substr_no_leaks(char *s, unsigned int start, size_t len)
+{
+    char    *temp;
+
+    temp = ft_substr(s, start, len);
+    free(s);
+    return (temp);
+}
+
+char *ft_strtrim_no_leaks(char *s1, const char *set)
+{
+    char    *temp;
+
+    temp = ft_strtrim(s1, set);
+    free(s1);
+    return (temp);
+}


### PR DESCRIPTION
Applies only to cases when the string the return value is assigned to was already malloc'ed.